### PR TITLE
Assignments were not correctly rendered

### DIFF
--- a/netbox_security/views/address.py
+++ b/netbox_security/views/address.py
@@ -85,7 +85,7 @@ class AddressContactsView(ObjectContactsView):
     queryset = Address.objects.all()
 
 
-@register_model_view(AddressAssignment, "add")
+@register_model_view(AddressAssignment, "add", detail=False)
 @register_model_view(AddressAssignment, "edit")
 class AddressAssignmentEditView(generic.ObjectEditView):
     queryset = AddressAssignment.objects.all()

--- a/netbox_security/views/address_list.py
+++ b/netbox_security/views/address_list.py
@@ -47,7 +47,7 @@ class AddressListDeleteView(generic.ObjectDeleteView):
     queryset = AddressList.objects.all()
 
 
-@register_model_view(AddressListAssignment, "add")
+@register_model_view(AddressListAssignment, "add", detail=False)
 @register_model_view(AddressListAssignment, "edit")
 class AddressListAssignmentEditView(generic.ObjectEditView):
     queryset = AddressListAssignment.objects.all()

--- a/netbox_security/views/address_set.py
+++ b/netbox_security/views/address_set.py
@@ -91,7 +91,7 @@ class AddressSetContactsView(ObjectContactsView):
     queryset = AddressSet.objects.all()
 
 
-@register_model_view(AddressSetAssignment, "add")
+@register_model_view(AddressSetAssignment, "add", detail=False)
 @register_model_view(AddressSetAssignment, "edit")
 class AddressSetAssignmentEditView(generic.ObjectEditView):
     queryset = AddressSetAssignment.objects.all()

--- a/netbox_security/views/firewall_filter.py
+++ b/netbox_security/views/firewall_filter.py
@@ -98,7 +98,7 @@ class FirewallFilterContactsView(ObjectContactsView):
     queryset = FirewallFilter.objects.all()
 
 
-@register_model_view(FirewallFilterAssignment, "add")
+@register_model_view(FirewallFilterAssignment, "add", detail=False)
 @register_model_view(FirewallFilterAssignment, "edit")
 class FirewallFilterAssignmentEditView(generic.ObjectEditView):
     queryset = FirewallFilterAssignment.objects.all()

--- a/netbox_security/views/nat_pool.py
+++ b/netbox_security/views/nat_pool.py
@@ -112,7 +112,7 @@ class NatPoolContactsView(ObjectContactsView):
     queryset = NatPool.objects.all()
 
 
-@register_model_view(NatPoolAssignment, "add")
+@register_model_view(NatPoolAssignment, "add", detail=False)
 @register_model_view(NatPoolAssignment, "edit")
 class NatPoolAssignmentEditView(generic.ObjectEditView):
     queryset = NatPoolAssignment.objects.all()

--- a/netbox_security/views/nat_rule.py
+++ b/netbox_security/views/nat_rule.py
@@ -115,7 +115,7 @@ class NatRuleContactsView(ObjectContactsView):
 
 
 @register_model_view(NatRuleAssignment, "edit")
-@register_model_view(NatRuleAssignment, "add")
+@register_model_view(NatRuleAssignment, "add", detail=False)
 class NatRuleAssignmentEditView(generic.ObjectEditView):
     queryset = NatRuleAssignment.objects.all()
     form = NatRuleAssignmentForm

--- a/netbox_security/views/nat_rule_set.py
+++ b/netbox_security/views/nat_rule_set.py
@@ -115,7 +115,7 @@ class NatRuleSetRulesView(generic.ObjectChildrenView):
         return self.child_model.objects.filter(rule_set=parent)
 
 
-@register_model_view(NatRuleSetAssignment, "add")
+@register_model_view(NatRuleSetAssignment, "add", detail=False)
 @register_model_view(NatRuleSetAssignment, "edit")
 class NatRuleSetAssignmentEditView(generic.ObjectEditView):
     queryset = NatRuleSetAssignment.objects.all()

--- a/netbox_security/views/securityzone.py
+++ b/netbox_security/views/securityzone.py
@@ -99,7 +99,7 @@ class SecurityZoneContactsView(ObjectContactsView):
     queryset = SecurityZone.objects.all()
 
 
-@register_model_view(SecurityZoneAssignment, "add")
+@register_model_view(SecurityZoneAssignment, "add", detail=False)
 @register_model_view(SecurityZoneAssignment, "edit")
 class SecurityZoneAssignmentEditView(generic.ObjectEditView):
     queryset = SecurityZoneAssignment.objects.all()


### PR DESCRIPTION
Assignment tables were not correctly rendered on the device and interface views, causing them to break