### PR TITLE
feat(security): add transitive policy context to IPAM and CustomPrefix views

### DIFF
--- a/netbox_security/forms/security_zone_policy.py
+++ b/netbox_security/forms/security_zone_policy.py
@@ -54,12 +54,10 @@ class SecurityZonePolicyForm(PrimaryModelForm):
     )
     source_address = DynamicModelMultipleChoiceField(
         queryset=AddressList.objects.all(),
-        quick_add=True,
         required=False,
     )
     destination_address = DynamicModelMultipleChoiceField(
         queryset=AddressList.objects.all(),
-        quick_add=True,
         required=False,
     )
     applications = DynamicModelMultipleChoiceField(

--- a/netbox_security/templates/netbox_security/customprefix.html
+++ b/netbox_security/templates/netbox_security/customprefix.html
@@ -1,5 +1,6 @@
 {% extends 'generic/object.html' %}
 {% load i18n %}
+{% load helpers %}
 {% load plugins %}
 {% load render_table from django_tables2 %}
 
@@ -40,6 +41,56 @@
             {% endif %}
             <div class="table-responsive">
                 {% render_table address_assignments_table 'inc/table.html' %}
+            </div>
+        </div>
+        <div class="card">
+            <h2 class="card-header">{% trans "Security Policy Context" %}</h2>
+            <div class="card-body">
+                {% if policy_context.policy_paths %}
+                    <table class="table table-hover attr-table">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Actions" %}</th>
+                                <th>{% trans "Direction" %}</th>
+                                <th>{% trans "Security Zones" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in policy_context.policy_paths %}
+                                <tr>
+                                    <td>{{ row.policy|linkify }}</td>
+                                    <td>
+                                        {% for action in row.policy_actions %}
+                                            <span class="badge text-bg-{% if action == 'permit' %}green
+                                            {% elif action == 'deny' %}red
+                                            {% elif action == 'log' %}orange
+                                            {% elif action == 'count' %}orange
+                                            {% elif action == 'reject' %}red
+                                            {% endif %}"
+                                            >{{ action }}</span>
+                                        {% endfor %}
+                                    </td>
+                                    <td>{{ row.direction }}</td>
+                                    <td>{{ row.source_zone|linkify }} &rarr; {{ row.destination_zone|linkify }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if policy_context.address_set_object_paths %}
+                        <p class="text-muted mb-1">{% trans "Address Set Hierarchy" %}</p>
+                        {% for path in policy_context.address_set_object_paths %}
+                            <div>
+                                {% for address_set in path %}
+                                    {% if not forloop.first %} &rarr; {% endif %}
+                                    {{ address_set|linkify }}
+                                {% endfor %}
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+                {% else %}
+                    <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
             </div>
         </div>
         {% include 'inc/panels/custom_fields.html' %}

--- a/netbox_security/templates/netbox_security/ipaddress/security.html
+++ b/netbox_security/templates/netbox_security/ipaddress/security.html
@@ -73,4 +73,58 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <h5 class="card-header">{% trans "Security Policy Context" %}</h5>
+            <div class="card-body">
+                {% if policy_context.policy_paths %}
+                    <table class="table table-hover attr-table">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Actions" %}</th>
+                                <th>{% trans "Direction" %}</th>
+                                <th>{% trans "Security Zones" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in policy_context.policy_paths %}
+                                <tr>
+                                    <td>{{ row.policy|linkify }}</td>
+                                    <td>
+                                        {% for action in row.policy_actions %}
+                                            <span class="badge text-bg-{% if action == 'permit' %}green
+                                            {% elif action == 'deny' %}red
+                                            {% elif action == 'log' %}orange
+                                            {% elif action == 'count' %}orange
+                                            {% elif action == 'reject' %}red
+                                            {% endif %}"
+                                            >{{ action }}</span>
+                                        {% endfor %}
+                                    </td>
+                                    <td>{{ row.direction }}</td>
+                                    <td>{{ row.source_zone|linkify }} &rarr; {{ row.destination_zone|linkify }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if policy_context.address_set_object_paths %}
+                        <p class="text-muted mb-1">{% trans "Address Set Hierarchy" %}</p>
+                        {% for path in policy_context.address_set_object_paths %}
+                            <div>
+                                {% for address_set in path %}
+                                    {% if not forloop.first %} &rarr; {% endif %}
+                                    {{ address_set|linkify }}
+                                {% endfor %}
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+                {% else %}
+                    <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/netbox_security/templates/netbox_security/iprange/security.html
+++ b/netbox_security/templates/netbox_security/iprange/security.html
@@ -73,4 +73,58 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <h5 class="card-header">{% trans "Security Policy Context" %}</h5>
+            <div class="card-body">
+                {% if policy_context.policy_paths %}
+                    <table class="table table-hover attr-table">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Actions" %}</th>
+                                <th>{% trans "Direction" %}</th>
+                                <th>{% trans "Security Zones" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in policy_context.policy_paths %}
+                                <tr>
+                                    <td>{{ row.policy|linkify }}</td>
+                                    <td>
+                                        {% for action in row.policy_actions %}
+                                            <span class="badge text-bg-{% if action == 'permit' %}green
+                                            {% elif action == 'deny' %}red
+                                            {% elif action == 'log' %}orange
+                                            {% elif action == 'count' %}orange
+                                            {% elif action == 'reject' %}red
+                                            {% endif %}"
+                                            >{{ action }}</span>
+                                        {% endfor %}
+                                    </td>
+                                    <td>{{ row.direction }}</td>
+                                    <td>{{ row.source_zone|linkify }} &rarr; {{ row.destination_zone|linkify }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if policy_context.address_set_object_paths %}
+                        <p class="text-muted mb-1">{% trans "Address Set Hierarchy" %}</p>
+                        {% for path in policy_context.address_set_object_paths %}
+                            <div>
+                                {% for address_set in path %}
+                                    {% if not forloop.first %} &rarr; {% endif %}
+                                    {{ address_set|linkify }}
+                                {% endfor %}
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+                {% else %}
+                    <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/netbox_security/templates/netbox_security/prefix/security.html
+++ b/netbox_security/templates/netbox_security/prefix/security.html
@@ -73,4 +73,58 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <h5 class="card-header">{% trans "Security Policy Context" %}</h5>
+            <div class="card-body">
+                {% if policy_context.policy_paths %}
+                    <table class="table table-hover attr-table">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Actions" %}</th>
+                                <th>{% trans "Direction" %}</th>
+                                <th>{% trans "Security Zones" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in policy_context.policy_paths %}
+                                <tr>
+                                    <td>{{ row.policy|linkify }}</td>
+                                    <td>
+                                        {% for action in row.policy_actions %}
+                                            <span class="badge text-bg-{% if action == 'permit' %}green
+                                            {% elif action == 'deny' %}red
+                                            {% elif action == 'log' %}orange
+                                            {% elif action == 'count' %}orange
+                                            {% elif action == 'reject' %}red
+                                            {% endif %}"
+                                            >{{ action }}</span>
+                                        {% endfor %}
+                                    </td>
+                                    <td>{{ row.direction }}</td>
+                                    <td>{{ row.source_zone|linkify }} &rarr; {{ row.destination_zone|linkify }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                    {% if policy_context.address_set_object_paths %}
+                        <p class="text-muted mb-1">{% trans "Address Set Hierarchy" %}</p>
+                        {% for path in policy_context.address_set_object_paths %}
+                            <div>
+                                {% for address_set in path %}
+                                    {% if not forloop.first %} &rarr; {% endif %}
+                                    {{ address_set|linkify }}
+                                {% endfor %}
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+                {% else %}
+                    <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/netbox_security/tests/address_set/test_hierarchy.py
+++ b/netbox_security/tests/address_set/test_hierarchy.py
@@ -1,0 +1,138 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from netaddr import IPNetwork
+
+from ipam.models import Prefix
+from netbox_security.models import (
+    Address,
+    AddressList,
+    AddressSet,
+    SecurityZone,
+    SecurityZonePolicy,
+)
+from netbox_security.utilities import get_address_set_hierarchy
+
+
+class AddressSetHierarchyTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/24"))
+        cls.address = Address.objects.create(
+            name="prefix-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="prefix",
+            ),
+            assigned_object_id=cls.prefix.pk,
+        )
+
+        cls.root_set = AddressSet.objects.create(name="root-set")
+        cls.leaf_set = AddressSet.objects.create(name="leaf-set")
+        cls.root_set.address_sets.add(cls.leaf_set)
+        cls.leaf_set.addresses.add(cls.address)
+
+        address_ct = ContentType.objects.get_for_model(Address)
+        address_set_ct = ContentType.objects.get_for_model(AddressSet)
+
+        cls.list_from_address = AddressList.objects.create(
+            name="list-from-address",
+            assigned_object_type=address_ct,
+            assigned_object_id=cls.address.pk,
+        )
+        cls.list_from_root_set = AddressList.objects.create(
+            name="list-from-root-set",
+            assigned_object_type=address_set_ct,
+            assigned_object_id=cls.root_set.pk,
+        )
+
+        cls.source_zone = SecurityZone.objects.create(name="source-zone")
+        cls.destination_zone = SecurityZone.objects.create(name="destination-zone")
+
+        cls.policy_source = SecurityZonePolicy.objects.create(
+            name="policy-source",
+            index=10,
+            source_zone=cls.source_zone,
+            destination_zone=cls.destination_zone,
+            policy_actions=["permit"],
+        )
+        cls.policy_source.source_address.add(cls.list_from_root_set)
+
+        cls.policy_destination = SecurityZonePolicy.objects.create(
+            name="policy-destination",
+            index=20,
+            source_zone=cls.source_zone,
+            destination_zone=cls.destination_zone,
+            policy_actions=["permit"],
+        )
+        cls.policy_destination.destination_address.add(cls.list_from_address)
+
+    def test_returns_transitive_addressset_and_policy_context(self):
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="prefix",
+            object_id=self.prefix.pk,
+        )
+
+        self.assertEqual(result["assigned_object_id"], self.prefix.pk)
+        self.assertIn(self.address.pk, result["address_ids"])
+
+        self.assertEqual(
+            set(result["direct_address_set_ids"]),
+            {self.leaf_set.pk},
+        )
+        self.assertEqual(
+            set(result["all_address_set_ids"]),
+            {self.root_set.pk, self.leaf_set.pk},
+        )
+        self.assertEqual(
+            {tuple(path) for path in result["address_set_paths"]},
+            {(self.root_set.pk, self.leaf_set.pk)},
+        )
+
+        self.assertEqual(
+            set(result["address_list_ids"]),
+            {self.list_from_address.pk, self.list_from_root_set.pk},
+        )
+
+        policy_markers = {
+            (row["policy_id"], row["direction"]) for row in result["policy_paths"]
+        }
+        self.assertEqual(
+            policy_markers,
+            {
+                (self.policy_source.pk, "source"),
+                (self.policy_destination.pk, "destination"),
+            },
+        )
+
+    def test_returns_empty_for_unassigned_ipam_object(self):
+        unassigned_prefix = Prefix.objects.create(prefix=IPNetwork("10.2.0.0/24"))
+
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="prefix",
+            object_id=unassigned_prefix.pk,
+        )
+
+        self.assertEqual(result["assigned_object_id"], unassigned_prefix.pk)
+        self.assertEqual(result["address_ids"], [])
+        self.assertEqual(result["direct_address_set_ids"], [])
+        self.assertEqual(result["all_address_set_ids"], [])
+        self.assertEqual(result["address_set_paths"], [])
+        self.assertEqual(result["address_list_ids"], [])
+        self.assertEqual(result["policy_paths"], [])
+
+    def test_returns_empty_for_unknown_content_type(self):
+        result = get_address_set_hierarchy(
+            app_label="not_real",
+            model="missing",
+            object_id=1,
+        )
+
+        self.assertIsNone(result["assigned_object_id"])
+        self.assertEqual(result["address_ids"], [])
+        self.assertEqual(result["direct_address_set_ids"], [])
+        self.assertEqual(result["all_address_set_ids"], [])
+        self.assertEqual(result["address_set_paths"], [])
+        self.assertEqual(result["address_list_ids"], [])
+        self.assertEqual(result["policy_paths"], [])

--- a/netbox_security/utilities/__init__.py
+++ b/netbox_security/utilities/__init__.py
@@ -1,0 +1,3 @@
+from .address_set_hierarchy import get_address_set_hierarchy
+
+__all__ = ("get_address_set_hierarchy",)

--- a/netbox_security/utilities/address_set_hierarchy.py
+++ b/netbox_security/utilities/address_set_hierarchy.py
@@ -1,0 +1,238 @@
+from collections import defaultdict
+
+from django.contrib.contenttypes.models import ContentType
+
+from netbox_security.models import Address, AddressList, AddressSet, SecurityZonePolicy
+
+
+def get_address_set_hierarchy(*, app_label, model, object_id):
+    """Return transitive security context for an assigned IPAM object.
+
+    Traversal:
+    assigned object -> Address -> AddressSet (direct + parent hierarchy) ->
+    AddressList -> SecurityZonePolicy (source/destination)
+    """
+    content_type = ContentType.objects.filter(app_label=app_label, model=model).first()
+    if not content_type:
+        return {
+            "assigned_object_id": None,
+            "address_ids": [],
+            "direct_address_set_ids": [],
+            "all_address_set_ids": [],
+            "address_set_paths": [],
+            "address_set_object_paths": [],
+            "address_set_name_paths": [],
+            "address_list_ids": [],
+            "address_list_names": [],
+            "policy_paths": [],
+        }
+
+    address_ids = list(
+        Address.objects.filter(
+            assigned_object_type=content_type,
+            assigned_object_id=object_id,
+        ).values_list("id", flat=True)
+    )
+    if not address_ids:
+        return {
+            "assigned_object_id": object_id,
+            "address_ids": [],
+            "direct_address_set_ids": [],
+            "all_address_set_ids": [],
+            "address_set_paths": [],
+            "address_set_object_paths": [],
+            "address_set_name_paths": [],
+            "address_list_ids": [],
+            "address_list_names": [],
+            "policy_paths": [],
+        }
+
+    direct_address_set_ids = set(
+        AddressSet.objects.filter(addresses__id__in=address_ids)
+        .values_list("id", flat=True)
+        .distinct()
+    )
+
+    relation_field = AddressSet._meta.get_field("address_sets")
+    parent_field = relation_field.m2m_field_name()
+    child_field = relation_field.m2m_reverse_field_name()
+    through_model = relation_field.remote_field.through
+
+    parent_map = defaultdict(set)
+    all_address_set_ids = set(direct_address_set_ids)
+    frontier = set(direct_address_set_ids)
+
+    while frontier:
+        relation_rows = through_model.objects.filter(
+            **{f"{child_field}_id__in": list(frontier)}
+        ).values_list(f"{parent_field}_id", f"{child_field}_id")
+
+        new_frontier = set()
+        for parent_id, child_id in relation_rows:
+            parent_map[child_id].add(parent_id)
+            if parent_id not in all_address_set_ids:
+                all_address_set_ids.add(parent_id)
+                new_frontier.add(parent_id)
+
+        frontier = new_frontier
+
+    def build_addressset_paths(child_id, trail=None):
+        if trail is None:
+            trail = set()
+        if child_id in trail:
+            return []
+
+        parents = sorted(parent_map.get(child_id, ()))
+        if not parents:
+            return [[child_id]]
+
+        paths = []
+        for parent_id in parents:
+            for parent_path in build_addressset_paths(parent_id, trail | {child_id}):
+                paths.append([*parent_path, child_id])
+        return paths
+
+    addressset_paths = []
+    for direct_id in sorted(direct_address_set_ids):
+        addressset_paths.extend(build_addressset_paths(direct_id))
+    unique_addressset_paths = sorted({tuple(path) for path in addressset_paths})
+    address_set_object_map = {
+        obj.pk: obj for obj in AddressSet.objects.filter(id__in=all_address_set_ids)
+    }
+
+    address_ct = ContentType.objects.get_for_model(Address)
+    address_set_ct = ContentType.objects.get_for_model(AddressSet)
+
+    address_list_ids = set(
+        AddressList.objects.filter(
+            assigned_object_type=address_ct,
+            assigned_object_id__in=address_ids,
+        ).values_list("id", flat=True)
+    )
+    if all_address_set_ids:
+        address_list_ids.update(
+            AddressList.objects.filter(
+                assigned_object_type=address_set_ct,
+                assigned_object_id__in=all_address_set_ids,
+            ).values_list("id", flat=True)
+        )
+    address_list_object_map = {
+        obj.pk: obj for obj in AddressList.objects.filter(id__in=address_list_ids)
+    }
+
+    policy_rows = []
+    policy_object_map = {}
+    if address_list_ids:
+        source_policies = SecurityZonePolicy.objects.filter(
+            source_address__id__in=address_list_ids
+        ).distinct()
+        destination_policies = SecurityZonePolicy.objects.filter(
+            destination_address__id__in=address_list_ids
+        ).distinct()
+
+        for policy in source_policies:
+            policy_object_map[policy.pk] = policy
+            policy_rows.append(
+                {
+                    "policy_id": policy.pk,
+                    "policy_name": policy.name,
+                    "policy_index": policy.index,
+                    "policy_actions": list(policy.policy_actions or []),
+                    "direction": "source",
+                    "source_zone_id": policy.source_zone_id,
+                    "destination_zone_id": policy.destination_zone_id,
+                    "source_zone_name": policy.source_zone.name,
+                    "destination_zone_name": policy.destination_zone.name,
+                }
+            )
+        for policy in destination_policies:
+            policy_object_map[policy.pk] = policy
+            policy_rows.append(
+                {
+                    "policy_id": policy.pk,
+                    "policy_name": policy.name,
+                    "policy_index": policy.index,
+                    "policy_actions": list(policy.policy_actions or []),
+                    "direction": "destination",
+                    "source_zone_id": policy.source_zone_id,
+                    "destination_zone_id": policy.destination_zone_id,
+                    "source_zone_name": policy.source_zone.name,
+                    "destination_zone_name": policy.destination_zone.name,
+                }
+            )
+
+    unique_policy_rows = sorted(
+        {
+            (
+                row["policy_id"],
+                row["policy_name"],
+                row["policy_index"],
+                tuple(row["policy_actions"]),
+                row["direction"],
+                row["source_zone_id"],
+                row["destination_zone_id"],
+                row["source_zone_name"],
+                row["destination_zone_name"],
+            )
+            for row in policy_rows
+        }
+    )
+
+    return {
+        "assigned_object_id": object_id,
+        "address_ids": sorted(address_ids),
+        "direct_address_set_ids": sorted(direct_address_set_ids),
+        "all_address_set_ids": sorted(all_address_set_ids),
+        "address_set_paths": [list(path) for path in unique_addressset_paths],
+        "address_set_object_paths": [
+            [address_set_object_map.get(address_set_id) for address_set_id in path]
+            for path in unique_addressset_paths
+        ],
+        "address_set_name_paths": [
+            [
+                (
+                    address_set_object_map.get(address_set_id).name
+                    if address_set_object_map.get(address_set_id)
+                    else str(address_set_id)
+                )
+                for address_set_id in path
+            ]
+            for path in unique_addressset_paths
+        ],
+        "address_list_ids": sorted(address_list_ids),
+        "address_list_objects": [
+            address_list_object_map[address_list_id]
+            for address_list_id in sorted(address_list_ids)
+            if address_list_id in address_list_object_map
+        ],
+        "address_list_names": [
+            address_list_object_map[address_list_id].name
+            for address_list_id in sorted(address_list_ids)
+            if address_list_id in address_list_object_map
+        ],
+        "policy_paths": [
+            {
+                "policy_id": row[0],
+                "policy_name": row[1],
+                "policy_index": row[2],
+                "policy_actions": list(row[3]),
+                "direction": row[4],
+                "source_zone_id": row[5],
+                "destination_zone_id": row[6],
+                "source_zone_name": row[7],
+                "destination_zone_name": row[8],
+                "policy": policy_object_map.get(row[0]),
+                "source_zone": (
+                    policy_object_map.get(row[0]).source_zone
+                    if policy_object_map.get(row[0])
+                    else None
+                ),
+                "destination_zone": (
+                    policy_object_map.get(row[0]).destination_zone
+                    if policy_object_map.get(row[0])
+                    else None
+                ),
+            }
+            for row in unique_policy_rows
+        ],
+    }

--- a/netbox_security/views/custom_prefix.py
+++ b/netbox_security/views/custom_prefix.py
@@ -8,6 +8,7 @@ from netbox_security.tables import (
 from netbox_security.filtersets import CustomPrefixFilterSet
 
 from netbox_security.models import CustomPrefix, Address
+from netbox_security.utilities import get_address_set_hierarchy
 from netbox_security.forms import (
     CustomPrefixFilterForm,
     CustomPrefixForm,
@@ -38,6 +39,11 @@ class CustomPrefixView(generic.ObjectView):
         )
         return {
             "address_assignments_table": address_assignments_table,
+            "policy_context": get_address_set_hierarchy(
+                app_label="netbox_security",
+                model="customprefix",
+                object_id=instance.pk,
+            ),
         }
 
 

--- a/netbox_security/views/tabs.py
+++ b/netbox_security/views/tabs.py
@@ -11,6 +11,7 @@ from netbox_security.models import (
     NatRule,
     SecurityZone,
 )
+from netbox_security.utilities import get_address_set_hierarchy
 
 from netbox.views import generic
 from utilities.views import register_model_view, ViewTab
@@ -129,6 +130,14 @@ def _iprange_related_total_count(obj):
     return _related_total_count(obj, IPRange, _annotate_iprange_queryset)
 
 
+def _policy_context(app_label, model, object_id):
+    return get_address_set_hierarchy(
+        app_label=app_label,
+        model=model,
+        object_id=object_id,
+    )
+
+
 @register_model_view(Device, name="security")
 class DeviceSecurityView(generic.ObjectView):
     queryset = Device.objects.all()
@@ -169,6 +178,11 @@ class IPAddressSecurityView(generic.ObjectView):
         hide_if_empty=True,
     )
 
+    def get_extra_context(self, request, instance):
+        return {
+            "policy_context": _policy_context("ipam", "ipaddress", instance.pk),
+        }
+
 
 @register_model_view(Prefix, name="security")
 class PrefixSecurityView(generic.ObjectView):
@@ -180,6 +194,11 @@ class PrefixSecurityView(generic.ObjectView):
         hide_if_empty=True,
     )
 
+    def get_extra_context(self, request, instance):
+        return {
+            "policy_context": _policy_context("ipam", "prefix", instance.pk),
+        }
+
 
 @register_model_view(IPRange, name="security")
 class IPRangeSecurityView(generic.ObjectView):
@@ -190,3 +209,8 @@ class IPRangeSecurityView(generic.ObjectView):
         badge=_iprange_related_total_count,
         hide_if_empty=True,
     )
+
+    def get_extra_context(self, request, instance):
+        return {
+            "policy_context": _policy_context("ipam", "iprange", instance.pk),
+        }


### PR DESCRIPTION
Implements issue #141 - show transitive Address Set membership and SecurityZonePolicy context in the Security tab for IPAM objects.

Traversal chain:
  IPAM object → Address → AddressSet (direct + transitive parents)
  → AddressList → SecurityZonePolicy (source/destination)

Changes:
- Add get_address_set_hierarchy() utility in utilities/address_set_hierarchy.py
  - Resolves Address records assigned to the IPAM object
  - Walks transitive AddressSet parent hierarchy (cycle-safe BFS)
  - Discovers AddressList membership via Address and AddressSet
  - Discovers SecurityZonePolicy references in both directions
  - Returns linkable model objects for all policy context fields
  - Includes policy_actions in each policy row

- Wire policy context into IPAM security tab views (views/tabs.py)
  - IPAddressSecurityView.get_extra_context()
  - PrefixSecurityView.get_extra_context()
  - IPRangeSecurityView.get_extra_context()

- Wire policy context into CustomPrefix detail view (views/custom_prefix.py)

- Add "Security Policy Context" card to security templates:
  - templates/netbox_security/ipaddress/security.html
  - templates/netbox_security/prefix/security.html
  - templates/netbox_security/iprange/security.html
  - templates/netbox_security/customprefix.html
  - Shows linked policy, color-coded policy action badges, address/destination direction, linked source/destination zones
  - Shows transitive AddressSet hierarchy paths as linked objects
  - Renders "No policy context found" when no policies apply

- Add unit tests for the hierarchy utility (tests/address_set/test_hierarchy.py)
  - test_returns_transitive_addressset_and_policy_context
  - test_returns_empty_for_unassigned_ipam_object
  - test_returns_empty_for_unknown_content_type

Closes: #141