### PR TITLE
feat(security-context): include Address/Set source in policy context rows

### DIFF
--- a/netbox_security/templates/netbox_security/customprefix.html
+++ b/netbox_security/templates/netbox_security/customprefix.html
@@ -50,6 +50,7 @@
                     <table class="table table-hover attr-table">
                         <thead>
                             <tr>
+                                <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
@@ -59,6 +60,15 @@
                         <tbody>
                             {% for row in policy_context.policy_paths %}
                                 <tr>
+                                    <td>
+                                        {% if row.context_object %}
+                                            {{ row.context_object|linkify }}
+                                        {% elif row.address_list %}
+                                            {{ row.address_list|linkify }}
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
                                     <td>{{ row.policy|linkify }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
@@ -77,22 +87,25 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                {% elif policy_context.address_set_object_paths %}
+                {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
                 {% elif policy_context.address_objects %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
                 {% endif %}
-                {% if policy_context.address_set_object_paths %}
+                {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>
                     <ul class="mb-0 ps-3">
-                        {% for path in policy_context.address_set_object_paths %}
+                        {% for row in policy_context.address_set_hierarchy_rows %}
                             <li class="mb-1">
-                                {% for address_set in path %}
+                                {% for address_set in row.path %}
                                     {% if not forloop.first %} &rarr; {% endif %}
                                     {{ address_set|linkify }}
                                 {% endfor %}
+                                {% if row.address %}
+                                    {% if row.path %} &rarr; {% endif %}[{{ row.address|linkify }}]
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>

--- a/netbox_security/templates/netbox_security/ipaddress/security.html
+++ b/netbox_security/templates/netbox_security/ipaddress/security.html
@@ -82,6 +82,7 @@
                     <table class="table table-hover attr-table">
                         <thead>
                             <tr>
+                                <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
@@ -91,6 +92,15 @@
                         <tbody>
                             {% for row in policy_context.policy_paths %}
                                 <tr>
+                                    <td>
+                                        {% if row.context_object %}
+                                            {{ row.context_object|linkify }}
+                                        {% elif row.address_list %}
+                                            {{ row.address_list|linkify }}
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
                                     <td>{{ row.policy|linkify }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
@@ -109,22 +119,25 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                {% elif policy_context.address_set_object_paths %}
+                {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
                 {% elif policy_context.address_objects %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
                 {% endif %}
-                {% if policy_context.address_set_object_paths %}
+                {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>
                     <ul class="mb-0 ps-3">
-                        {% for path in policy_context.address_set_object_paths %}
+                        {% for row in policy_context.address_set_hierarchy_rows %}
                             <li class="mb-1">
-                                {% for address_set in path %}
+                                {% for address_set in row.path %}
                                     {% if not forloop.first %} &rarr; {% endif %}
                                     {{ address_set|linkify }}
                                 {% endfor %}
+                                {% if row.address %}
+                                    {% if row.path %} &rarr; {% endif %}[{{ row.address|linkify }}]
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>

--- a/netbox_security/templates/netbox_security/iprange/security.html
+++ b/netbox_security/templates/netbox_security/iprange/security.html
@@ -82,6 +82,7 @@
                     <table class="table table-hover attr-table">
                         <thead>
                             <tr>
+                                <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
@@ -91,6 +92,15 @@
                         <tbody>
                             {% for row in policy_context.policy_paths %}
                                 <tr>
+                                    <td>
+                                        {% if row.context_object %}
+                                            {{ row.context_object|linkify }}
+                                        {% elif row.address_list %}
+                                            {{ row.address_list|linkify }}
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
                                     <td>{{ row.policy|linkify }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
@@ -109,22 +119,25 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                {% elif policy_context.address_set_object_paths %}
+                {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
                 {% elif policy_context.address_objects %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
                 {% endif %}
-                {% if policy_context.address_set_object_paths %}
+                {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>
                     <ul class="mb-0 ps-3">
-                        {% for path in policy_context.address_set_object_paths %}
+                        {% for row in policy_context.address_set_hierarchy_rows %}
                             <li class="mb-1">
-                                {% for address_set in path %}
+                                {% for address_set in row.path %}
                                     {% if not forloop.first %} &rarr; {% endif %}
                                     {{ address_set|linkify }}
                                 {% endfor %}
+                                {% if row.address %}
+                                    {% if row.path %} &rarr; {% endif %}[{{ row.address|linkify }}]
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>

--- a/netbox_security/templates/netbox_security/prefix/security.html
+++ b/netbox_security/templates/netbox_security/prefix/security.html
@@ -82,6 +82,7 @@
                     <table class="table table-hover attr-table">
                         <thead>
                             <tr>
+                                <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
@@ -91,6 +92,15 @@
                         <tbody>
                             {% for row in policy_context.policy_paths %}
                                 <tr>
+                                    <td>
+                                        {% if row.context_object %}
+                                            {{ row.context_object|linkify }}
+                                        {% elif row.address_list %}
+                                            {{ row.address_list|linkify }}
+                                        {% else %}
+                                            <span class="text-muted">-</span>
+                                        {% endif %}
+                                    </td>
                                     <td>{{ row.policy|linkify }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
@@ -109,22 +119,25 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                {% elif policy_context.address_set_object_paths %}
+                {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
                 {% elif policy_context.address_objects %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
                 {% endif %}
-                {% if policy_context.address_set_object_paths %}
+                {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>
                     <ul class="mb-0 ps-3">
-                        {% for path in policy_context.address_set_object_paths %}
+                        {% for row in policy_context.address_set_hierarchy_rows %}
                             <li class="mb-1">
-                                {% for address_set in path %}
+                                {% for address_set in row.path %}
                                     {% if not forloop.first %} &rarr; {% endif %}
                                     {{ address_set|linkify }}
                                 {% endfor %}
+                                {% if row.address %}
+                                    {% if row.path %} &rarr; {% endif %}[{{ row.address|linkify }}]
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>

--- a/netbox_security/tests/address_set/test_hierarchy.py
+++ b/netbox_security/tests/address_set/test_hierarchy.py
@@ -75,6 +75,9 @@ class AddressSetHierarchyTestCase(TestCase):
 
         self.assertEqual(result["assigned_object_id"], self.prefix.pk)
         self.assertIn(self.address.pk, result["address_ids"])
+        self.assertEqual(
+            [obj.pk for obj in result["address_objects"]], [self.address.pk]
+        )
 
         self.assertEqual(
             set(result["direct_address_set_ids"]),
@@ -87,6 +90,15 @@ class AddressSetHierarchyTestCase(TestCase):
         self.assertEqual(
             {tuple(path) for path in result["address_set_paths"]},
             {(self.root_set.pk, self.leaf_set.pk)},
+        )
+        self.assertEqual(len(result["address_set_hierarchy_rows"]), 1)
+        self.assertEqual(
+            [obj.pk for obj in result["address_set_hierarchy_rows"][0]["path"]],
+            [self.root_set.pk, self.leaf_set.pk],
+        )
+        self.assertEqual(
+            result["address_set_hierarchy_rows"][0]["address"].pk,
+            self.address.pk,
         )
 
         self.assertEqual(
@@ -104,6 +116,10 @@ class AddressSetHierarchyTestCase(TestCase):
                 (self.policy_destination.pk, "destination"),
             },
         )
+        for row in result["policy_paths"]:
+            self.assertIn("context_object", row)
+            self.assertIn("address_list", row)
+        self.assertTrue(any(row["context_object"] for row in result["policy_paths"]))
 
     def test_returns_empty_for_unassigned_ipam_object(self):
         unassigned_prefix = Prefix.objects.create(prefix=IPNetwork("10.2.0.0/24"))
@@ -116,9 +132,11 @@ class AddressSetHierarchyTestCase(TestCase):
 
         self.assertEqual(result["assigned_object_id"], unassigned_prefix.pk)
         self.assertEqual(result["address_ids"], [])
+        self.assertEqual(result["address_objects"], [])
         self.assertEqual(result["direct_address_set_ids"], [])
         self.assertEqual(result["all_address_set_ids"], [])
         self.assertEqual(result["address_set_paths"], [])
+        self.assertEqual(result["address_set_hierarchy_rows"], [])
         self.assertEqual(result["address_list_ids"], [])
         self.assertEqual(result["policy_paths"], [])
 
@@ -131,8 +149,10 @@ class AddressSetHierarchyTestCase(TestCase):
 
         self.assertIsNone(result["assigned_object_id"])
         self.assertEqual(result["address_ids"], [])
+        self.assertEqual(result["address_objects"], [])
         self.assertEqual(result["direct_address_set_ids"], [])
         self.assertEqual(result["all_address_set_ids"], [])
         self.assertEqual(result["address_set_paths"], [])
+        self.assertEqual(result["address_set_hierarchy_rows"], [])
         self.assertEqual(result["address_list_ids"], [])
         self.assertEqual(result["policy_paths"], [])

--- a/netbox_security/utilities/address_set_hierarchy.py
+++ b/netbox_security/utilities/address_set_hierarchy.py
@@ -22,6 +22,7 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
             "all_address_set_ids": [],
             "address_set_paths": [],
             "address_set_object_paths": [],
+            "address_set_hierarchy_rows": [],
             "address_set_name_paths": [],
             "address_list_ids": [],
             "address_list_names": [],
@@ -43,6 +44,7 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
             "all_address_set_ids": [],
             "address_set_paths": [],
             "address_set_object_paths": [],
+            "address_set_hierarchy_rows": [],
             "address_set_name_paths": [],
             "address_list_ids": [],
             "address_list_names": [],
@@ -95,12 +97,34 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
         return paths
 
     addressset_paths = []
+    paths_by_direct_set = {}
     for direct_id in sorted(direct_address_set_ids):
-        addressset_paths.extend(build_addressset_paths(direct_id))
+        direct_paths = build_addressset_paths(direct_id)
+        paths_by_direct_set[direct_id] = direct_paths
+        addressset_paths.extend(direct_paths)
     unique_addressset_paths = sorted({tuple(path) for path in addressset_paths})
+    direct_memberships = (
+        AddressSet.objects.filter(addresses__id__in=address_ids)
+        .values_list("addresses__id", "id")
+        .distinct()
+    )
+    direct_sets_by_address = defaultdict(set)
+    for address_id, address_set_id in direct_memberships:
+        direct_sets_by_address[address_id].add(address_set_id)
+
+    address_object_map = {
+        obj.pk: obj for obj in Address.objects.filter(id__in=address_ids)
+    }
     address_set_object_map = {
         obj.pk: obj for obj in AddressSet.objects.filter(id__in=all_address_set_ids)
     }
+
+    hierarchy_rows = set()
+    for address_id in sorted(address_ids):
+        for direct_set_id in sorted(direct_sets_by_address.get(address_id, ())):
+            for path in paths_by_direct_set.get(direct_set_id, [[direct_set_id]]):
+                hierarchy_rows.add((tuple(path), address_id))
+    sorted_hierarchy_rows = sorted(hierarchy_rows)
 
     address_ct = ContentType.objects.get_for_model(Address)
     address_set_ct = ContentType.objects.get_for_model(AddressSet)
@@ -132,8 +156,30 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
             destination_address__id__in=address_list_ids
         ).distinct()
 
+        source_policy_ids = set(source_policies.values_list("id", flat=True))
+        destination_policy_ids = set(destination_policies.values_list("id", flat=True))
+
         for policy in source_policies:
             policy_object_map[policy.pk] = policy
+        for policy in destination_policies:
+            policy_object_map[policy.pk] = policy
+
+        source_links = SecurityZonePolicy.source_address.through.objects.filter(
+            securityzonepolicy_id__in=source_policy_ids,
+            addresslist_id__in=address_list_ids,
+        ).values_list("securityzonepolicy_id", "addresslist_id")
+        destination_links = (
+            SecurityZonePolicy.destination_address.through.objects.filter(
+                securityzonepolicy_id__in=destination_policy_ids,
+                addresslist_id__in=address_list_ids,
+            ).values_list("securityzonepolicy_id", "addresslist_id")
+        )
+
+        for policy_id, address_list_id in source_links:
+            policy = policy_object_map.get(policy_id)
+            address_list = address_list_object_map.get(address_list_id)
+            if not policy:
+                continue
             policy_rows.append(
                 {
                     "policy_id": policy.pk,
@@ -145,10 +191,26 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
                     "destination_zone_id": policy.destination_zone_id,
                     "source_zone_name": policy.source_zone.name,
                     "destination_zone_name": policy.destination_zone.name,
+                    "address_list_id": address_list_id,
+                    "address_list_name": address_list.name if address_list else "",
+                    "context_model": (
+                        address_list.assigned_object_type.model
+                        if address_list and address_list.assigned_object_type_id
+                        else ""
+                    ),
+                    "context_object_id": (
+                        address_list.assigned_object_id
+                        if address_list and address_list.assigned_object_id
+                        else 0
+                    ),
                 }
             )
-        for policy in destination_policies:
-            policy_object_map[policy.pk] = policy
+
+        for policy_id, address_list_id in destination_links:
+            policy = policy_object_map.get(policy_id)
+            address_list = address_list_object_map.get(address_list_id)
+            if not policy:
+                continue
             policy_rows.append(
                 {
                     "policy_id": policy.pk,
@@ -160,6 +222,18 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
                     "destination_zone_id": policy.destination_zone_id,
                     "source_zone_name": policy.source_zone.name,
                     "destination_zone_name": policy.destination_zone.name,
+                    "address_list_id": address_list_id,
+                    "address_list_name": address_list.name if address_list else "",
+                    "context_model": (
+                        address_list.assigned_object_type.model
+                        if address_list and address_list.assigned_object_type_id
+                        else ""
+                    ),
+                    "context_object_id": (
+                        address_list.assigned_object_id
+                        if address_list and address_list.assigned_object_id
+                        else 0
+                    ),
                 }
             )
 
@@ -175,6 +249,10 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
                 row["destination_zone_id"],
                 row["source_zone_name"],
                 row["destination_zone_name"],
+                row["address_list_id"],
+                row["address_list_name"],
+                row["context_model"],
+                row["context_object_id"],
             )
             for row in policy_rows
         }
@@ -192,6 +270,16 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
         "address_set_object_paths": [
             [address_set_object_map.get(address_set_id) for address_set_id in path]
             for path in unique_addressset_paths
+        ],
+        "address_set_hierarchy_rows": [
+            {
+                "path": [
+                    address_set_object_map.get(address_set_id)
+                    for address_set_id in path
+                ],
+                "address": address_object_map.get(address_id),
+            }
+            for path, address_id in sorted_hierarchy_rows
         ],
         "address_set_name_paths": [
             [
@@ -226,6 +314,16 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
                 "destination_zone_id": row[6],
                 "source_zone_name": row[7],
                 "destination_zone_name": row[8],
+                "address_list_id": row[9],
+                "address_list_name": row[10],
+                "address_list": address_list_object_map.get(row[9]),
+                "context_model": row[11],
+                "context_object_id": row[12],
+                "context_object": (
+                    address_list_object_map.get(row[9]).assigned_object
+                    if address_list_object_map.get(row[9])
+                    else None
+                ),
                 "policy": policy_object_map.get(row[0]),
                 "source_zone": (
                     policy_object_map.get(row[0]).source_zone


### PR DESCRIPTION
Expand Security Policy Context rows to show the originating Address or AddressSet per matched AddressList membership.

Changes:
- utilities/address_set_hierarchy.py
  - Build policy rows per policy/address-list link (source + destination)
  - Add context metadata to each policy row:
    - context_object (Address or AddressSet when resolvable)
    - context_model, context_object_id
    - address_list, address_list_id, address_list_name
  - Keep existing fields intact (policy, policy_actions, direction, zones)
  - Continue returning hierarchy rows with explicit Address leaf and direct address fallback fields

- templates/netbox_security/*/security.html
  - Add new first column: "Address/Set" in Security Policy Context tables
  - Render context_object (linkified), fallback to address_list, fallback "-"
  - Preserve policy action color badges and existing columns/order: Address/Set -> Security Policy -> Policy Actions -> Direction -> Zones

- tests/address_set/test_hierarchy.py
  - Assert policy row context keys are present
  - Assert at least one policy row has a resolved context_object

Notes:
- No schema/API migration required
- UI behavior remains backward compatible while adding disambiguation context