### PR TITLE
feat(policy-context): surface inherited address policy context

### DIFF
--- a/netbox_security/templates/netbox_security/customprefix.html
+++ b/netbox_security/templates/netbox_security/customprefix.html
@@ -52,6 +52,7 @@
                             <tr>
                                 <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Index" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
                                 <th>{% trans "Security Zones" %}</th>
@@ -70,6 +71,7 @@
                                         {% endif %}
                                     </td>
                                     <td>{{ row.policy|linkify }}</td>
+                                    <td>{{ row.policy_index }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
                                             <span class="badge text-bg-{% if action == 'permit' %}green
@@ -89,10 +91,18 @@
                     </table>
                 {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
-                {% elif policy_context.address_objects %}
-                    <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
+                {% elif policy_context.address_objects or policy_context.inherited_address_objects %}
+                    <span class="text-muted">{% trans "No policy context found yet; showing Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
+                {% if policy_context.inherited_address_objects %}
+                    <p class="text-muted mb-1 mt-2">{% trans "Inherited Addresses (from parent prefixes)" %}</p>
+                    <ul class="mb-0 ps-3">
+                        {% for address in policy_context.inherited_address_objects %}
+                            <li class="mb-1">{{ address|linkify }}</li>
+                        {% endfor %}
+                    </ul>
                 {% endif %}
                 {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>

--- a/netbox_security/templates/netbox_security/ipaddress/security.html
+++ b/netbox_security/templates/netbox_security/ipaddress/security.html
@@ -84,6 +84,7 @@
                             <tr>
                                 <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Index" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
                                 <th>{% trans "Security Zones" %}</th>
@@ -102,6 +103,7 @@
                                         {% endif %}
                                     </td>
                                     <td>{{ row.policy|linkify }}</td>
+                                    <td>{{ row.policy_index }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
                                             <span class="badge text-bg-{% if action == 'permit' %}green
@@ -121,10 +123,18 @@
                     </table>
                 {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
-                {% elif policy_context.address_objects %}
-                    <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
+                {% elif policy_context.address_objects or policy_context.inherited_address_objects %}
+                    <span class="text-muted">{% trans "No policy context found yet; showing Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
+                {% if policy_context.inherited_address_objects %}
+                    <p class="text-muted mb-1 mt-2">{% trans "Inherited Addresses (from parent prefixes)" %}</p>
+                    <ul class="mb-0 ps-3">
+                        {% for address in policy_context.inherited_address_objects %}
+                            <li class="mb-1">{{ address|linkify }}</li>
+                        {% endfor %}
+                    </ul>
                 {% endif %}
                 {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>

--- a/netbox_security/templates/netbox_security/iprange/security.html
+++ b/netbox_security/templates/netbox_security/iprange/security.html
@@ -84,6 +84,7 @@
                             <tr>
                                 <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Index" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
                                 <th>{% trans "Security Zones" %}</th>
@@ -102,6 +103,7 @@
                                         {% endif %}
                                     </td>
                                     <td>{{ row.policy|linkify }}</td>
+                                    <td>{{ row.policy_index }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
                                             <span class="badge text-bg-{% if action == 'permit' %}green
@@ -121,10 +123,18 @@
                     </table>
                 {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
-                {% elif policy_context.address_objects %}
-                    <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
+                {% elif policy_context.address_objects or policy_context.inherited_address_objects %}
+                    <span class="text-muted">{% trans "No policy context found yet; showing Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
+                {% if policy_context.inherited_address_objects %}
+                    <p class="text-muted mb-1 mt-2">{% trans "Inherited Addresses (from parent prefixes)" %}</p>
+                    <ul class="mb-0 ps-3">
+                        {% for address in policy_context.inherited_address_objects %}
+                            <li class="mb-1">{{ address|linkify }}</li>
+                        {% endfor %}
+                    </ul>
                 {% endif %}
                 {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>

--- a/netbox_security/templates/netbox_security/prefix/security.html
+++ b/netbox_security/templates/netbox_security/prefix/security.html
@@ -84,6 +84,7 @@
                             <tr>
                                 <th>{% trans "Address/Set" %}</th>
                                 <th>{% trans "Security Policy" %}</th>
+                                <th>{% trans "Policy Index" %}</th>
                                 <th>{% trans "Policy Actions" %}</th>
                                 <th>{% trans "Direction" %}</th>
                                 <th>{% trans "Security Zones" %}</th>
@@ -102,6 +103,7 @@
                                         {% endif %}
                                     </td>
                                     <td>{{ row.policy|linkify }}</td>
+                                    <td>{{ row.policy_index }}</td>
                                     <td>
                                         {% for action in row.policy_actions %}
                                             <span class="badge text-bg-{% if action == 'permit' %}green
@@ -121,10 +123,18 @@
                     </table>
                 {% elif policy_context.address_set_hierarchy_rows %}
                     <span class="text-muted">{% trans "No policy context found yet; showing Address Set hierarchy." %}</span>
-                {% elif policy_context.address_objects %}
-                    <span class="text-muted">{% trans "No policy context found yet; showing Direct Addresses." %}</span>
+                {% elif policy_context.address_objects or policy_context.inherited_address_objects %}
+                    <span class="text-muted">{% trans "No policy context found yet; showing Addresses." %}</span>
                 {% else %}
                     <span class="text-muted">{% trans "No policy context found for this object." %}</span>
+                {% endif %}
+                {% if policy_context.inherited_address_objects %}
+                    <p class="text-muted mb-1 mt-2">{% trans "Inherited Addresses (from parent prefixes)" %}</p>
+                    <ul class="mb-0 ps-3">
+                        {% for address in policy_context.inherited_address_objects %}
+                            <li class="mb-1">{{ address|linkify }}</li>
+                        {% endfor %}
+                    </ul>
                 {% endif %}
                 {% if policy_context.address_set_hierarchy_rows %}
                     <p class="text-muted mb-1 mt-2">{% trans "Address Set Hierarchy" %}</p>

--- a/netbox_security/tests/address_set/test_inherited_addresses.py
+++ b/netbox_security/tests/address_set/test_inherited_addresses.py
@@ -1,0 +1,514 @@
+"""Tests for inherited address functionality in Security Policy Context."""
+
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from netaddr import IPNetwork
+
+from ipam.models import IPAddress, IPRange, Prefix
+from netbox_security.models import (
+    Address,
+    AddressList,
+    AddressSet,
+    CustomPrefix,
+    SecurityZone,
+    SecurityZonePolicy,
+)
+from netbox_security.utilities import get_address_set_hierarchy
+
+
+class PrefixInheritedAddressTestCase(TestCase):
+    """Test that child prefixes inherit addresses from parent prefixes."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent and child prefixes
+        cls.parent_prefix = Prefix.objects.create(prefix=IPNetwork("10.0.0.0/8"))
+        cls.child_prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/24"))
+        # A child prefix with NO direct address assignment at all
+        cls.child_prefix_no_direct = Prefix.objects.create(
+            prefix=IPNetwork("10.2.0.0/24")
+        )
+
+        # Create address assigned to parent
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="prefix",
+            ),
+            assigned_object_id=cls.parent_prefix.pk,
+        )
+
+        # Create address assigned to child
+        cls.child_address = Address.objects.create(
+            name="child-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="prefix",
+            ),
+            assigned_object_id=cls.child_prefix.pk,
+        )
+
+        # Create address sets
+        cls.parent_set = AddressSet.objects.create(name="parent-set")
+        cls.parent_set.addresses.add(cls.parent_address)
+
+        cls.child_set = AddressSet.objects.create(name="child-set")
+        cls.child_set.addresses.add(cls.child_address)
+
+    def test_child_prefix_inherits_parent_addresses(self):
+        """Child prefix should show both direct and inherited addresses."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="prefix",
+            object_id=self.child_prefix.pk,
+        )
+
+        # Should have direct address
+        self.assertIn(self.child_address.pk, result["address_ids"])
+        self.assertEqual(
+            [obj.pk for obj in result["address_objects"]], [self.child_address.pk]
+        )
+
+        # Should have inherited address from parent
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+        self.assertEqual(
+            [obj.pk for obj in result["inherited_address_objects"]],
+            [self.parent_address.pk],
+        )
+
+    def test_child_prefix_no_direct_address_inherits_parent_addresses(self):
+        """Child prefix with no direct address should still show inherited addresses."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="prefix",
+            object_id=self.child_prefix_no_direct.pk,
+        )
+
+        # No direct addresses
+        self.assertEqual(result["address_ids"], [])
+        self.assertEqual(result["address_objects"], [])
+
+        # Should still have inherited address from parent
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+        self.assertGreater(len(result["inherited_address_objects"]), 0)
+
+    def test_parent_prefix_shows_own_addresses_not_inherited(self):
+        """Parent prefix should not show child addresses as inherited."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="prefix",
+            object_id=self.parent_prefix.pk,
+        )
+
+        # Should have direct address
+        self.assertIn(self.parent_address.pk, result["address_ids"])
+
+        # Should not have child address
+        self.assertNotIn(self.child_address.pk, result["address_ids"])
+        self.assertEqual(result["inherited_address_ids"], [])
+
+
+class IPAddressInheritedAddressTestCase(TestCase):
+    """Test that IP addresses inherit addresses from parent prefixes."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent prefix
+        cls.parent_prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/24"))
+
+        # IP address within the prefix that has a direct Address assignment
+        cls.ip_address_with_direct = IPAddress.objects.create(
+            address=IPNetwork("10.1.0.5/24")
+        )
+
+        # IP address within the prefix with NO direct Address assignment
+        cls.ip_address_no_direct = IPAddress.objects.create(
+            address=IPNetwork("10.1.0.6/24")
+        )
+
+        # Create address assigned to parent prefix
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="prefix",
+            ),
+            assigned_object_id=cls.parent_prefix.pk,
+        )
+
+        # Create address assigned directly to the IP address
+        cls.ip_direct_address = Address.objects.create(
+            name="ip-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="ipaddress",
+            ),
+            assigned_object_id=cls.ip_address_with_direct.pk,
+        )
+
+    def test_ip_address_with_direct_also_inherits_parent(self):
+        """IP address with a direct assignment should also show inherited parent addresses."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="ipaddress",
+            object_id=self.ip_address_with_direct.pk,
+        )
+
+        self.assertIn(self.ip_direct_address.pk, result["address_ids"])
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+
+    def test_ip_address_no_direct_inherits_parent(self):
+        """IP address with NO direct assignment should show inherited parent addresses."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="ipaddress",
+            object_id=self.ip_address_no_direct.pk,
+        )
+
+        # No direct addresses
+        self.assertEqual(result["address_ids"], [])
+        self.assertEqual(result["address_objects"], [])
+
+        # Should still inherit from parent prefix
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+        self.assertGreater(len(result["inherited_address_objects"]), 0)
+
+
+class IPRangeInheritedAddressTestCase(TestCase):
+    """Test that IP ranges inherit addresses from parent prefixes."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent prefix
+        cls.parent_prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/24"))
+
+        # IP range fully inside the prefix, with NO direct Address assignment
+        cls.ip_range_no_direct = IPRange.objects.create(
+            start_address=IPNetwork("10.1.0.10/24"),
+            end_address=IPNetwork("10.1.0.20/24"),
+        )
+
+        # Create address assigned to parent prefix
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="prefix",
+            ),
+            assigned_object_id=cls.parent_prefix.pk,
+        )
+
+    def test_ip_range_no_direct_inherits_parent(self):
+        """IP range with NO direct assignment should show inherited parent prefix addresses."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="iprange",
+            object_id=self.ip_range_no_direct.pk,
+        )
+
+        # No direct addresses
+        self.assertEqual(result["address_ids"], [])
+
+        # Should inherit from parent prefix
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+
+
+class InheritedAddressSetHierarchyTestCase(TestCase):
+    """Test that inherited addresses are included in address set hierarchy."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent and child prefixes
+        cls.parent_prefix = Prefix.objects.create(prefix=IPNetwork("10.0.0.0/8"))
+        cls.child_prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/24"))
+
+        # Create address assigned to parent
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="prefix",
+            ),
+            assigned_object_id=cls.parent_prefix.pk,
+        )
+
+        # Create address set hierarchy
+        cls.root_set = AddressSet.objects.create(name="root-set")
+        cls.leaf_set = AddressSet.objects.create(name="leaf-set")
+        cls.root_set.address_sets.add(cls.leaf_set)
+        cls.leaf_set.addresses.add(cls.parent_address)
+
+    def test_child_prefix_shows_inherited_address_set_hierarchy(self):
+        """Child prefix should show address set hierarchy for inherited addresses."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="prefix",
+            object_id=self.child_prefix.pk,
+        )
+
+        # Should have inherited address from parent
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+
+        # Should have address set hierarchy rows (transitive)
+        hierarchy_rows = result["address_set_hierarchy_rows"]
+        self.assertTrue(len(hierarchy_rows) > 0)
+
+        # Verify the hierarchy includes the root and leaf sets
+        address_set_ids_in_rows = set()
+        for row in hierarchy_rows:
+            for address_set in row["path"]:
+                if address_set:
+                    address_set_ids_in_rows.add(address_set.pk)
+
+        self.assertIn(self.root_set.pk, address_set_ids_in_rows)
+        self.assertIn(self.leaf_set.pk, address_set_ids_in_rows)
+
+
+class InheritedAddressPolicyContextTestCase(TestCase):
+    """Test that inherited addresses are used in policy context."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent and child prefixes
+        cls.parent_prefix = Prefix.objects.create(prefix=IPNetwork("10.0.0.0/8"))
+        cls.child_prefix = Prefix.objects.create(prefix=IPNetwork("10.1.0.0/24"))
+
+        # Create address assigned to parent
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="ipam",
+                model="prefix",
+            ),
+            assigned_object_id=cls.parent_prefix.pk,
+        )
+
+        # Create address set
+        cls.address_set = AddressSet.objects.create(name="address-set")
+        cls.address_set.addresses.add(cls.parent_address)
+
+        # Create address list
+        address_set_ct = ContentType.objects.get_for_model(AddressSet)
+        cls.address_list = AddressList.objects.create(
+            name="policy-list",
+            assigned_object_type=address_set_ct,
+            assigned_object_id=cls.address_set.pk,
+        )
+
+        # Create security zones and policy
+        cls.source_zone = SecurityZone.objects.create(name="source-zone")
+        cls.destination_zone = SecurityZone.objects.create(name="dest-zone")
+        cls.policy = SecurityZonePolicy.objects.create(
+            name="test-policy",
+            index=10,
+            source_zone=cls.source_zone,
+            destination_zone=cls.destination_zone,
+            policy_actions=["permit"],
+        )
+        cls.policy.source_address.add(cls.address_list)
+
+    def test_child_prefix_shows_policy_from_inherited_addresses(self):
+        """Child prefix should show policy derived from inherited addresses."""
+        result = get_address_set_hierarchy(
+            app_label="ipam",
+            model="prefix",
+            object_id=self.child_prefix.pk,
+        )
+
+        # Should have policy paths
+        policy_paths = result["policy_paths"]
+        self.assertTrue(len(policy_paths) > 0)
+
+        # Verify the policy is included
+        policy_ids = [p["policy_id"] for p in policy_paths]
+        self.assertIn(self.policy.pk, policy_ids)
+
+
+class CustomPrefixInheritedAddressTestCase(TestCase):
+    """Test that child custom prefixes inherit addresses from parent custom prefixes."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent and child custom prefixes
+        cls.parent_custom_prefix = CustomPrefix.objects.create(
+            prefix=IPNetwork("10.0.0.0/8")
+        )
+        cls.child_custom_prefix = CustomPrefix.objects.create(
+            prefix=IPNetwork("10.1.0.0/24")
+        )
+
+        # Create address assigned to parent
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="netbox_security",
+                model="customprefix",
+            ),
+            assigned_object_id=cls.parent_custom_prefix.pk,
+        )
+
+        # Create address assigned to child
+        cls.child_address = Address.objects.create(
+            name="child-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="netbox_security",
+                model="customprefix",
+            ),
+            assigned_object_id=cls.child_custom_prefix.pk,
+        )
+
+    def test_child_custom_prefix_inherits_parent_addresses(self):
+        """Child custom prefix should show both direct and inherited addresses."""
+        result = get_address_set_hierarchy(
+            app_label="netbox_security",
+            model="customprefix",
+            object_id=self.child_custom_prefix.pk,
+        )
+
+        # Should have direct address
+        self.assertIn(self.child_address.pk, result["address_ids"])
+        self.assertEqual(
+            [obj.pk for obj in result["address_objects"]], [self.child_address.pk]
+        )
+
+        # Should have inherited address from parent
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+        self.assertEqual(
+            [obj.pk for obj in result["inherited_address_objects"]],
+            [self.parent_address.pk],
+        )
+
+    def test_parent_custom_prefix_shows_own_addresses_not_inherited(self):
+        """Parent custom prefix should not show child addresses as inherited."""
+        result = get_address_set_hierarchy(
+            app_label="netbox_security",
+            model="customprefix",
+            object_id=self.parent_custom_prefix.pk,
+        )
+
+        # Should have direct address
+        self.assertIn(self.parent_address.pk, result["address_ids"])
+
+        # Should not have child address
+        self.assertNotIn(self.child_address.pk, result["address_ids"])
+        self.assertEqual(result["inherited_address_ids"], [])
+
+
+class CustomPrefixInheritedAddressSetHierarchyTestCase(TestCase):
+    """Test that inherited addresses from custom prefixes are included in hierarchy."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent and child custom prefixes
+        cls.parent_custom_prefix = CustomPrefix.objects.create(
+            prefix=IPNetwork("10.0.0.0/8")
+        )
+        cls.child_custom_prefix = CustomPrefix.objects.create(
+            prefix=IPNetwork("10.1.0.0/24")
+        )
+
+        # Create address assigned to parent
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="netbox_security",
+                model="customprefix",
+            ),
+            assigned_object_id=cls.parent_custom_prefix.pk,
+        )
+
+        # Create address set hierarchy
+        cls.root_set = AddressSet.objects.create(name="root-set")
+        cls.leaf_set = AddressSet.objects.create(name="leaf-set")
+        cls.root_set.address_sets.add(cls.leaf_set)
+        cls.leaf_set.addresses.add(cls.parent_address)
+
+    def test_child_custom_prefix_shows_inherited_address_set_hierarchy(self):
+        """Child custom prefix should show address set hierarchy for inherited addresses."""
+        result = get_address_set_hierarchy(
+            app_label="netbox_security",
+            model="customprefix",
+            object_id=self.child_custom_prefix.pk,
+        )
+
+        # Should have inherited address from parent
+        self.assertIn(self.parent_address.pk, result["inherited_address_ids"])
+
+        # Should have address set hierarchy rows (transitive)
+        hierarchy_rows = result["address_set_hierarchy_rows"]
+        self.assertTrue(len(hierarchy_rows) > 0)
+
+        # Verify the hierarchy includes the root and leaf sets
+        address_set_ids_in_rows = set()
+        for row in hierarchy_rows:
+            for address_set in row["path"]:
+                if address_set:
+                    address_set_ids_in_rows.add(address_set.pk)
+
+        self.assertIn(self.root_set.pk, address_set_ids_in_rows)
+        self.assertIn(self.leaf_set.pk, address_set_ids_in_rows)
+
+
+class CustomPrefixInheritedAddressPolicyContextTestCase(TestCase):
+    """Test that inherited addresses from custom prefixes are used in policy context."""
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create parent and child custom prefixes
+        cls.parent_custom_prefix = CustomPrefix.objects.create(
+            prefix=IPNetwork("10.0.0.0/8")
+        )
+        cls.child_custom_prefix = CustomPrefix.objects.create(
+            prefix=IPNetwork("10.1.0.0/24")
+        )
+
+        # Create address assigned to parent
+        cls.parent_address = Address.objects.create(
+            name="parent-address",
+            assigned_object_type=ContentType.objects.get(
+                app_label="netbox_security",
+                model="customprefix",
+            ),
+            assigned_object_id=cls.parent_custom_prefix.pk,
+        )
+
+        # Create address set
+        cls.address_set = AddressSet.objects.create(name="address-set")
+        cls.address_set.addresses.add(cls.parent_address)
+
+        # Create address list
+        address_set_ct = ContentType.objects.get_for_model(AddressSet)
+        cls.address_list = AddressList.objects.create(
+            name="policy-list",
+            assigned_object_type=address_set_ct,
+            assigned_object_id=cls.address_set.pk,
+        )
+
+        # Create security zones and policy
+        cls.source_zone = SecurityZone.objects.create(name="source-zone")
+        cls.destination_zone = SecurityZone.objects.create(name="dest-zone")
+        cls.policy = SecurityZonePolicy.objects.create(
+            name="test-policy",
+            index=10,
+            source_zone=cls.source_zone,
+            destination_zone=cls.destination_zone,
+            policy_actions=["permit"],
+        )
+        cls.policy.source_address.add(cls.address_list)
+
+    def test_child_custom_prefix_shows_policy_from_inherited_addresses(self):
+        """Child custom prefix should show policy derived from inherited addresses."""
+        result = get_address_set_hierarchy(
+            app_label="netbox_security",
+            model="customprefix",
+            object_id=self.child_custom_prefix.pk,
+        )
+
+        # Should have policy paths
+        policy_paths = result["policy_paths"]
+        self.assertTrue(len(policy_paths) > 0)
+
+        # Verify the policy is included
+        policy_ids = [p["policy_id"] for p in policy_paths]
+        self.assertIn(self.policy.pk, policy_ids)

--- a/netbox_security/utilities/address_set_hierarchy.py
+++ b/netbox_security/utilities/address_set_hierarchy.py
@@ -5,6 +5,116 @@ from django.contrib.contenttypes.models import ContentType
 from netbox_security.models import Address, AddressList, AddressSet, SecurityZonePolicy
 
 
+def _get_inherited_address_ids(target_object, direct_address_ids):
+    """Get address IDs inherited from parent objects.
+
+    For Prefix, IPRange, and IPAddress objects, traverse up the IPAM hierarchy
+    to find addresses assigned to parent prefixes.
+    For CustomPrefix objects, find parent CustomPrefixes that contain them.
+    """
+    from ipam.models import Prefix
+    from netbox_security.models import CustomPrefix
+
+    inherited_address_ids = []
+
+    # Only IPAM objects and CustomPrefix can have inheritance
+    if not hasattr(target_object, "_meta"):
+        return inherited_address_ids
+
+    model_name = target_object._meta.model_name
+
+    # Handle Prefix inheritance
+    if model_name == "prefix":
+        # Get parent prefixes and their addresses
+        parent_prefixes = target_object.get_parents()
+        parent_address_ids = list(
+            Address.objects.filter(
+                assigned_object_type__app_label="ipam",
+                assigned_object_type__model="prefix",
+                assigned_object_id__in=parent_prefixes.values_list("id", flat=True),
+            ).values_list("id", flat=True)
+        )
+        inherited_address_ids.extend(parent_address_ids)
+
+    # Handle IPRange inheritance
+    elif model_name == "iprange":
+        # Get all prefixes that contain this IP range.
+        # Use .ip to strip the mask and compare host addresses only, matching
+        # how NetBox itself resolves parent prefixes for an IPRange (ipam/views.py).
+        if target_object.vrf:
+            parent_prefixes = Prefix.objects.filter(
+                vrf=target_object.vrf,
+                prefix__net_contains_or_equals=str(target_object.start_address.ip),
+            ).filter(
+                prefix__net_contains_or_equals=str(target_object.end_address.ip),
+            )
+        else:
+            parent_prefixes = Prefix.objects.filter(
+                vrf__isnull=True,
+                prefix__net_contains_or_equals=str(target_object.start_address.ip),
+            ).filter(
+                prefix__net_contains_or_equals=str(target_object.end_address.ip),
+            )
+        parent_address_ids = list(
+            Address.objects.filter(
+                assigned_object_type__app_label="ipam",
+                assigned_object_type__model="prefix",
+                assigned_object_id__in=parent_prefixes.values_list("id", flat=True),
+            ).values_list("id", flat=True)
+        )
+        inherited_address_ids.extend(parent_address_ids)
+
+    # Handle IPAddress inheritance
+    elif model_name == "ipaddress":
+        # Get all prefixes that contain this IP address.
+        # Use prefix__net_contains with the bare host address (no mask), matching
+        # how NetBox's own filterset resolves parent prefixes for an IPAddress
+        # (ipam/filtersets.py line 488).
+        if target_object.vrf:
+            parent_prefixes = Prefix.objects.filter(
+                vrf=target_object.vrf,
+                prefix__net_contains=str(target_object.address.ip),
+            )
+        else:
+            parent_prefixes = Prefix.objects.filter(
+                vrf__isnull=True,
+                prefix__net_contains=str(target_object.address.ip),
+            )
+        parent_address_ids = list(
+            Address.objects.filter(
+                assigned_object_type__app_label="ipam",
+                assigned_object_type__model="prefix",
+                assigned_object_id__in=parent_prefixes.values_list("id", flat=True),
+            ).values_list("id", flat=True)
+        )
+        inherited_address_ids.extend(parent_address_ids)
+
+    # Handle CustomPrefix inheritance
+    elif model_name == "customprefix":
+        # Resolve parent custom prefixes using NetBox-style network lookup semantics.
+        # Use stringified prefix for consistent DB operator behavior and exclude self.
+        parent_custom_prefixes = CustomPrefix.objects.filter(
+            prefix__net_contains_or_equals=str(target_object.prefix),
+        ).exclude(pk=target_object.pk)
+        parent_address_ids = list(
+            Address.objects.filter(
+                assigned_object_type__app_label="netbox_security",
+                assigned_object_type__model="customprefix",
+                assigned_object_id__in=parent_custom_prefixes.values_list(
+                    "id", flat=True
+                ),
+            ).values_list("id", flat=True)
+        )
+        inherited_address_ids.extend(parent_address_ids)
+
+    # Remove direct addresses from inherited list to avoid duplicates
+    return [
+        addr_id
+        for addr_id in inherited_address_ids
+        if addr_id not in direct_address_ids
+    ]
+
+
 def get_address_set_hierarchy(*, app_label, model, object_id):
     """Return transitive security context for an assigned IPAM object.
 
@@ -18,6 +128,8 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
             "assigned_object_id": None,
             "address_ids": [],
             "address_objects": [],
+            "inherited_address_ids": [],
+            "inherited_address_objects": [],
             "direct_address_set_ids": [],
             "all_address_set_ids": [],
             "address_set_paths": [],
@@ -35,11 +147,23 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
             assigned_object_id=object_id,
         ).values_list("id", flat=True)
     )
-    if not address_ids:
+
+    # Get inherited addresses for IPAM child objects and CustomPrefix
+    inherited_address_ids = []
+    target_object = content_type.model_class().objects.filter(pk=object_id).first()
+    if target_object:
+        inherited_address_ids = _get_inherited_address_ids(target_object, address_ids)
+
+    # Combine direct and inherited addresses for hierarchy computation
+    effective_address_ids = sorted(set(address_ids) | set(inherited_address_ids))
+
+    if not effective_address_ids:
         return {
             "assigned_object_id": object_id,
             "address_ids": [],
             "address_objects": [],
+            "inherited_address_ids": [],
+            "inherited_address_objects": [],
             "direct_address_set_ids": [],
             "all_address_set_ids": [],
             "address_set_paths": [],
@@ -57,14 +181,21 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
         .distinct()
     )
 
+    # Also get address sets from inherited addresses
+    inherited_address_set_ids = set(
+        AddressSet.objects.filter(addresses__id__in=inherited_address_ids)
+        .values_list("id", flat=True)
+        .distinct()
+    )
+
     relation_field = AddressSet._meta.get_field("address_sets")
     parent_field = relation_field.m2m_field_name()
     child_field = relation_field.m2m_reverse_field_name()
     through_model = relation_field.remote_field.through
 
     parent_map = defaultdict(set)
-    all_address_set_ids = set(direct_address_set_ids)
-    frontier = set(direct_address_set_ids)
+    all_address_set_ids = set(direct_address_set_ids) | inherited_address_set_ids
+    frontier = all_address_set_ids.copy()
 
     while frontier:
         relation_rows = through_model.objects.filter(
@@ -98,7 +229,7 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
 
     addressset_paths = []
     paths_by_direct_set = {}
-    for direct_id in sorted(direct_address_set_ids):
+    for direct_id in sorted(direct_address_set_ids | inherited_address_set_ids):
         direct_paths = build_addressset_paths(direct_id)
         paths_by_direct_set[direct_id] = direct_paths
         addressset_paths.extend(direct_paths)
@@ -108,19 +239,28 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
         .values_list("addresses__id", "id")
         .distinct()
     )
+    # Also get memberships from inherited addresses
+    inherited_memberships = (
+        AddressSet.objects.filter(addresses__id__in=inherited_address_ids)
+        .values_list("addresses__id", "id")
+        .distinct()
+    )
+
     direct_sets_by_address = defaultdict(set)
     for address_id, address_set_id in direct_memberships:
         direct_sets_by_address[address_id].add(address_set_id)
+    for address_id, address_set_id in inherited_memberships:
+        direct_sets_by_address[address_id].add(address_set_id)
 
     address_object_map = {
-        obj.pk: obj for obj in Address.objects.filter(id__in=address_ids)
+        obj.pk: obj for obj in Address.objects.filter(id__in=effective_address_ids)
     }
     address_set_object_map = {
         obj.pk: obj for obj in AddressSet.objects.filter(id__in=all_address_set_ids)
     }
 
     hierarchy_rows = set()
-    for address_id in sorted(address_ids):
+    for address_id in sorted(effective_address_ids):
         for direct_set_id in sorted(direct_sets_by_address.get(address_id, ())):
             for path in paths_by_direct_set.get(direct_set_id, [[direct_set_id]]):
                 hierarchy_rows.add((tuple(path), address_id))
@@ -132,7 +272,7 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
     address_list_ids = set(
         AddressList.objects.filter(
             assigned_object_type=address_ct,
-            assigned_object_id__in=address_ids,
+            assigned_object_id__in=effective_address_ids,
         ).values_list("id", flat=True)
     )
     if all_address_set_ids:
@@ -255,7 +395,8 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
                 row["context_object_id"],
             )
             for row in policy_rows
-        }
+        },
+        key=lambda row: (row[2], row[0], row[4], row[9]),
     )
 
     return {
@@ -263,6 +404,10 @@ def get_address_set_hierarchy(*, app_label, model, object_id):
         "address_ids": sorted(address_ids),
         "address_objects": list(
             Address.objects.filter(id__in=address_ids).order_by("name", "pk")
+        ),
+        "inherited_address_ids": sorted(inherited_address_ids),
+        "inherited_address_objects": list(
+            Address.objects.filter(id__in=inherited_address_ids).order_by("name", "pk")
         ),
         "direct_address_set_ids": sorted(direct_address_set_ids),
         "all_address_set_ids": sorted(all_address_set_ids),

--- a/netbox_security/views/tabs.py
+++ b/netbox_security/views/tabs.py
@@ -119,15 +119,24 @@ def _related_total_count(obj, model, annotate_queryset):
 
 
 def _ipaddress_related_total_count(obj):
-    return _related_total_count(obj, IPAddress, _annotate_ipaddress_queryset)
+    return max(
+        _related_total_count(obj, IPAddress, _annotate_ipaddress_queryset),
+        _policy_context_related_total_count("ipam", "ipaddress", obj.pk),
+    )
 
 
 def _prefix_related_total_count(obj):
-    return _related_total_count(obj, Prefix, _annotate_prefix_queryset)
+    return max(
+        _related_total_count(obj, Prefix, _annotate_prefix_queryset),
+        _policy_context_related_total_count("ipam", "prefix", obj.pk),
+    )
 
 
 def _iprange_related_total_count(obj):
-    return _related_total_count(obj, IPRange, _annotate_iprange_queryset)
+    return max(
+        _related_total_count(obj, IPRange, _annotate_iprange_queryset),
+        _policy_context_related_total_count("ipam", "iprange", obj.pk),
+    )
 
 
 def _policy_context(app_label, model, object_id):
@@ -136,6 +145,19 @@ def _policy_context(app_label, model, object_id):
         model=model,
         object_id=object_id,
     )
+
+
+def _policy_context_related_total_count(app_label, model, object_id):
+    """Count total security context items including inherited addresses."""
+    policy_context = _policy_context(app_label, model, object_id)
+
+    # Count all relevant items: direct addresses, inherited addresses, and policy paths
+    count = (
+        len(policy_context.get("address_objects", []))
+        + len(policy_context.get("inherited_address_objects", []))
+        + len(policy_context.get("policy_paths", []))
+    )
+    return count
 
 
 @register_model_view(Device, name="security")


### PR DESCRIPTION
Includes inherited address resolution for Prefix/IPAddress/IPRange/CustomPrefix, keeps Security tab visible for inherited-only context, orders policy rows by policy index, adds Policy Index to policy context tables, and updates inherited context tests/fixtures.